### PR TITLE
Refactoring for code reuse

### DIFF
--- a/bandwidth.js
+++ b/bandwidth.js
@@ -2,16 +2,40 @@ var rp = require('request-promise');
 
 var client = {};
 client.get = function(url, options) {
-    var promise = rp.get(url, options)
-    .then(function (response) {
-        console.log('Response: ', response);
-        return response;
-    })
-    .catch(function (err) {
-        // API call failed... 
-        console.log('Error: ', err);
-        throw err;
-    });
+    var promise = 
+        rp.get(url, options)
+        .then(function (response) {
+            console.log('Response: ', response);
+            return response;
+        })
+        .catch(function (err) {
+            // API call failed... 
+            console.log('Error: ', err);
+            throw err;
+        });
+
+    return promise;
+}
+client.post = function(url, options, body) {
+    var promise = 
+        rp.post(url, {
+            auth: options.auth,
+            body: body,
+            headers: [
+                {
+                  name: 'content-type',
+                  value: 'application/xml'
+                }
+            ]
+        })
+        .then(function (response) {
+            console.log(response);
+            return response;
+        })
+        .catch(function (err) {
+            console.log('Error: ', err);
+            throw err;
+        });
 
     return promise;
 }

--- a/bandwidth.js
+++ b/bandwidth.js
@@ -1,0 +1,19 @@
+var rp = require('request-promise');
+
+var client = {};
+client.get = function(url, options) {
+    var promise = rp.get(url, options)
+    .then(function (response) {
+        console.log('Response: ', response);
+        return response;
+    })
+    .catch(function (err) {
+        // API call failed... 
+        console.log('Error: ', err);
+        throw err;
+    });
+
+    return promise;
+}
+
+module.exports = client;

--- a/converters.js
+++ b/converters.js
@@ -1,0 +1,51 @@
+var parser = require('xml2json');
+var _ = require('lodash');
+
+var validateAddress = {};
+validateAddress.createXmlString = function(obj) {
+    var address = {
+        validateLocation: {
+            location: {
+                address1: { $t: obj.addressLine1 },
+                address2: { $t: obj.addressLine2 },
+                community: { $t: obj.community },
+                state: { $t: obj.state },
+                postalcode: { $t: obj.postalCode },
+                type: { $t: 'ADDRESS' }
+            }
+        }
+    };
+    var xml = parser.toXml(address);
+    return xml;
+}
+validateAddress.createJsObject = function(xml) {
+    var json = parser.toJson(xml, { object: true });
+    var location = json['ns2:validateLocationResponse'].Location; 
+
+    var address = {
+      addressId: location.locationid['xsi:nil'] ? null : location.locationid,
+      addressLine1: location.address1,
+      addressLine2: _.isEmpty(location.address2) ? '' : location.address2,
+      houseNumber: location.legacydata.housenumber,
+      prefixDirectional: location.legacydata.predirectional,
+      streetName: location.legacydata.streetname,
+      //postDirectional: Unknown. Not in the Bandwidth response
+      //streetSuffix: Unknown. Not in the Bandwidth response
+      community: location.community,
+      state: location.state,
+      //unitType: Unknown. Not in the Bandwidth response
+      //unitTypeValue: Unknown. Not in the Bandwidth response
+      longitude: location.longitude,
+      latitude: location.latitude,
+      postalCode: location.postalcode,
+      zipPlusFour: location.plusfour,
+      //description: Unknown. Description found in response: "Location is geocoded"
+      addressStatus: location.status.code,
+      //createdOn: Unknown. activatedtime/updatetime found in response
+      //modifiedOn: Unknown. activatedtime/updatetime found in response
+    };
+
+    return address;
+}
+
+module.exports = {validateAddress};

--- a/converters.js
+++ b/converters.js
@@ -48,4 +48,63 @@ validateAddress.createJsObject = function(xml) {
     return address;
 }
 
-module.exports = {validateAddress};
+var addAddress = {};
+addAddress.createXmlString = function(obj) {
+    var address = {
+        addLocation: {
+            uri: {
+                callername: { $t: obj.endpoint.callerName },
+                uri: { $t: obj.endpoint.did },
+            },
+            location: {
+                address1: { $t: obj.addressLine1 },
+                address2: { $t: obj.addressLine2 },
+                callername: { $t: obj.endpoint.callerName },
+                community: { $t: obj.community },
+                postalcode: { $t: obj.postalCode },
+                state: { $t: obj.state },
+                type: { $t: 'ADDRESS' },
+            }
+        }
+    };
+    var xml = parser.toXml(address);
+    return xml;
+};
+addAddress.createJsObject = function(xml, did) {
+    var json = parser.toJson(xml, { object: true });
+    var location = json['ns2:addLocationResponse'].Location; 
+
+    var address = {
+      addressId: location.locationid, 
+      addressLine1: location.address1,
+      addressLine2: location.address2['xsi:nil'] ? null : location.address2,
+      houseNumber: location.legacydata.housenumber,
+      prefixDirectional: location.legacydata.predirectional,
+      streetName: location.legacydata.streetname,
+      //postDirectional: '', Unknown. Not in the Bandwidth response
+      //streetSuffix: '', Unknown. Not in the Bandwidth response
+      community: location.community,
+      state: location.state,
+      //unitType: '', Unknown. Not in the Bandwidth response
+      //unitTypeValue: '', Unknown. Not in the Bandwidth response
+      longitude: location.longitude,
+      latitude: location.latitude,
+      postalCode: location.postalcode,
+      zipPlusFour: location.plusfour,
+      //description: '', Unknown. Description found in response: "Location is geocoded"
+      addressStatus: location.status.code,
+      //createdOn: '', Unknown. activatedtime/updatetime found in response
+      //modifiedOn: '', Unknown. activatedtime/updatetime found in response
+      endpoint: {
+        did: did, // Not found in the Bandwidth response, but was part of the request
+        callerName: location.callername
+      }
+    };
+
+    return address;
+};
+
+module.exports = {
+    validateAddress,
+    addAddress
+};

--- a/converters.js
+++ b/converters.js
@@ -104,7 +104,24 @@ addAddress.createJsObject = function(xml, did) {
     return address;
 };
 
+var provisionAddress = {};
+provisionAddress.createXmlString = function(obj) {
+    var locationId = {
+        provisionLocation: {
+            locationid: { $t: obj } // Function takes a single int as a request
+        }
+    };
+    var xml = parser.toXml(locationId);
+    return xml;
+};
+provisionAddress.createJsObject = function(xml) {
+    var json = parser.toJson(xml, { object: true });
+    var status = json['ns2:provisionLocationResponse'].LocationStatus;
+    return status.code; // Function returns only a single string;
+};
+
 module.exports = {
     validateAddress,
-    addAddress
+    addAddress,
+    provisionAddress
 };

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var rp = require('request-promise');
 var restify = require('restify');
 var parser = require('xml2json');
 var converters = require('./converters');
+var bandwidth = require('./bandwidth');
 var options = {
   'auth': {
     'sendImmediately': true
@@ -125,17 +126,13 @@ function provisionAddress(req, res, next) {
 }
 
 function authCheck(req, res, next) {
-  rp.get(config.dash.url + 'authenticationcheck ', options)
+  bandwidth.get(config.dash.url + 'authenticationcheck ', options)
     .then(function (response) {
-      console.log('Response: ', response);
-      // res.writeHead(200, { 'Content-Type': 'text/xml' });
       res.send(response);
       next();
     })
     .catch(function (err) {
       // API call failed... 
-      console.log('Error: ', err);
-      res.writeHead(400, { 'Content-Type': 'text/plain' });
-      res.end(err);
+      next(err);
     });
 }

--- a/index.js
+++ b/index.js
@@ -88,7 +88,6 @@ function addAddress(req, res, next) {
   .then(function (response) {
     // One property is missing from the XML response, but is contained in the original request.
     var location = converter.createJsObject(response, req.body.endpoint.did);
-
     res.json(location);
     next();
   })
@@ -100,14 +99,12 @@ function addAddress(req, res, next) {
 }
 
 function provisionAddress(req, res, next) {
-  var locationId = {
-    provisionLocation: {
-      locationid: { $t: req.body } // Function takes a single int as a request
-    }
-  };
+  var converter = converters.provisionAddress;
+  
+  var xml = converter.createXmlString(req.body);
   rp.post(config.dash.url + 'provisionlocation', {
     auth: options.auth,
-    body: parser.toXml(locationId),
+    body: xml,
     headers: [
         {
           name: 'content-type',
@@ -116,11 +113,8 @@ function provisionAddress(req, res, next) {
       ]
   })
   .then(function (response) {
-    var json = parser.toJson(response, { object: true });
-    var status = json['ns2:provisionLocationResponse'].LocationStatus; 
-    console.log(status);
-
-    res.send(status.code);
+    var status = converter.createJsObject(response);
+    res.send(status);
     next();
   })
   .catch(function (err) {

--- a/index.js
+++ b/index.js
@@ -29,9 +29,9 @@ server.use(function (req, res, next) {
   }
 });
 
-server.post(/ValidateAddress/i, validateAddress);
-server.post(/AddAddress/i, addAddress);
-server.post(/ProvisionAddress/i, provisionAddress);
+server.post({ path: '/ValidateAddress', flags: 'i' }, validateAddress);
+server.post({ path: '/AddAddress', flags: 'i' }, addAddress);
+server.post({ path: '/ProvisionAddress', flags: 'i' }, provisionAddress);
 
 
 server.get('/', function (req, res, next) {

--- a/index.js
+++ b/index.js
@@ -34,12 +34,7 @@ server.post({ path: '/ValidateAddress', flags: 'i' }, validateAddress);
 server.post({ path: '/AddAddress', flags: 'i' }, addAddress);
 server.post({ path: '/ProvisionAddress', flags: 'i' }, provisionAddress);
 
-
-server.get('/', function (req, res, next) {
-  // console.log(req);
-  authCheck(req, res, next);
-});
-
+server.get('/', authCheck);
 
 server.listen(config.port, function () {
   console.log('Listening on ', config.port);

--- a/index.js
+++ b/index.js
@@ -49,25 +49,14 @@ function validateAddress(req, res, next) {
   var converter = converters.validateAddress;
 
   var xml = converter.createXmlString(req.body);
-  rp.post(config.dash.url + 'validatelocation', {
-    auth: options.auth,
-    body: xml,
-    headers: [
-        {
-          name: 'content-type',
-          value: 'application/xml'
-        }
-      ]
-  })
+  bandwidth.post(config.dash.url + 'validatelocation', options, xml)
   .then(function (response) {
     var obj = converter.createJsObject(response);
     res.json(obj);
     next();
   })
   .catch(function (err) {
-    console.log('Error: ', err);
-    res.writeHead(400, { 'Content-Type': 'text/plain' });
-    res.end(err);
+    next(err);
   });
 }
 
@@ -76,16 +65,7 @@ function addAddress(req, res, next) {
   
   var xml = converter.createXmlString(req.body);
 
-  rp.post(config.dash.url + 'addlocation', {
-    auth: options.auth,
-    body: xml,
-    headers: [
-        {
-          name: 'content-type',
-          value: 'application/xml'
-        }
-      ]
-  })
+  bandwidth.post(config.dash.url + 'addlocation', options, xml)
   .then(function (response) {
     // One property is missing from the XML response, but is contained in the original request.
     var location = converter.createJsObject(response, req.body.endpoint.did);
@@ -93,9 +73,7 @@ function addAddress(req, res, next) {
     next();
   })
   .catch(function (err) {
-    console.log('Error: ', err);
-    res.writeHead(400, { 'Content-Type': 'text/plain' });
-    res.end(err);
+    next(err);
   })
 }
 
@@ -103,25 +81,14 @@ function provisionAddress(req, res, next) {
   var converter = converters.provisionAddress;
   
   var xml = converter.createXmlString(req.body);
-  rp.post(config.dash.url + 'provisionlocation', {
-    auth: options.auth,
-    body: xml,
-    headers: [
-        {
-          name: 'content-type',
-          value: 'application/xml'
-        }
-      ]
-  })
+  bandwidth.post(config.dash.url + 'provisionlocation', options, xml)
   .then(function (response) {
     var status = converter.createJsObject(response);
     res.send(status);
     next();
   })
   .catch(function (err) {
-    console.log('Error: ', err);
-    res.writeHead(400, { 'Content-Type': 'text/plain' });
-    res.end(err);
+    next(err);
   })
 }
 


### PR DESCRIPTION
I pulled the conversions into their own module so that they follow a standard interface. With a few more changes, we could grab the correct converter dynamically. I also extracted a few functions relating to Bandwidth API calls. They are almost identical, except for the URL. As currently written, validateAddress and provisionAddress are identical except for a magic string. Can you see a way to refactor those as well?